### PR TITLE
feat: add Spinner component and bump @hivespace/shared to 1.1.16

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,3 +3,12 @@
 All development guidelines for this project have been consolidated into `CLAUDE.md`.
 
 Please read `CLAUDE.md` before making any changes in this repository.
+
+## Loading States (mandatory)
+
+Never write raw `<div class="animate-spin ...">` inline. Always use the shared components from `@hivespace/shared`:
+
+- **`<Spinner />`** — for inline/section loading (table, list, card content area). Props: `size` (`'sm'` | `'md'` | `'lg'`, default `'md'`).
+- **`<FullscreenLoader :visible="bool" :message="string" />`** — for full-UI blocking operations (form submit, destructive actions). Place at template root so it teleports to `<body>`.
+
+Decision rule: if the user cannot interact with the rest of the page while waiting → `FullscreenLoader`; otherwise → `Spinner`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -128,6 +128,33 @@ For each new backend domain, follow these four steps in order:
 - **Composables**: Extract reusable stateful logic into `src/composables/` (e.g. `useModal.ts`, `usePagination.ts`). One composable per logical concern.
 - **Icons**: New SVG icons go into `src/icons/` as `.vue` components and must be exported from `src/icons/index.ts`.
 
+## Loading States
+
+Always use the shared loading components from `@hivespace/shared`. Never write raw `<div class="animate-spin ...">` inline.
+
+| Situation | Component | When to use |
+|---|---|---|
+| Data loading inside a page section (table, list, card) | `<Spinner />` | The rest of the page stays interactive; only the content area is replaced |
+| Blocking the entire UI (form submit, destructive action) | `<FullscreenLoader :visible="bool" :message="string" />` | User must not interact until the operation finishes |
+
+**`Spinner`** — props: `size` (`'sm'` \| `'md'` \| `'lg'`, default `'md'`). Import from `@hivespace/shared`.
+
+```vue
+<!-- inline table/list loading state -->
+<div v-if="appStore.isLoading" class="p-8 text-center">
+  <Spinner />
+  <p class="mt-2 text-gray-600 dark:text-gray-400">{{ $t('...loading') }}</p>
+</div>
+```
+
+**`FullscreenLoader`** — props: `visible` (boolean, required), `message` (string, optional). Import from `@hivespace/shared`. Place it at the root of the template so it teleports to `<body>`.
+
+```vue
+<FullscreenLoader :visible="submitting" :message="$t('...processing')" />
+```
+
+If unsure which to use, ask: "Does the user need to wait for this before doing anything else on the page?" → yes → `FullscreenLoader`; no → `Spinner`.
+
 ## Types & Interfaces
 
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@fullcalendar/list": "^6.1.15",
         "@fullcalendar/timegrid": "^6.1.15",
         "@fullcalendar/vue3": "^6.1.15",
-        "@hivespace/shared": "^1.1.15",
+        "@hivespace/shared": "^1.1.16",
         "@tailwindcss/forms": "^0.5.10",
         "@tailwindcss/typography": "^0.5.16",
         "@tailwindcss/vite": "^4.1.17",
@@ -1251,9 +1251,9 @@
       }
     },
     "node_modules/@hivespace/shared": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/@hivespace/shared/-/shared-1.1.15.tgz",
-      "integrity": "sha512-ZAWCWKCE/icIo4v1mZKPL5SLo5ldL0MAHPsT8lZtdQrSDbbv/2eOcEltoTTFo+8HpTrs8Ugk6J1Y7tgVlCJPuA==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/@hivespace/shared/-/shared-1.1.16.tgz",
+      "integrity": "sha512-/jgZIuTXXObYSFxkXTCaszRuSly1UYV2VJHnMmgZpXgeD1NKsDLP2HpTfZQxqEMKy8OpwTia+QpO4Tp8+qpQEA==",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.13.4",
@@ -7908,6 +7908,14 @@
           "optional": true
         }
       }
+    },
+    "node_modules/vue-final-modal/node_modules/jwt-decode": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-3.1.2.tgz",
+      "integrity": "sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/vue-flatpickr-component": {
       "version": "11.0.5",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@fullcalendar/list": "^6.1.15",
     "@fullcalendar/timegrid": "^6.1.15",
     "@fullcalendar/vue3": "^6.1.15",
-    "@hivespace/shared": "^1.1.15",
+    "@hivespace/shared": "^1.1.16",
     "@tailwindcss/forms": "^0.5.10",
     "@tailwindcss/typography": "^0.5.16",
     "@tailwindcss/vite": "^4.1.17",

--- a/src/views/Marketing/CouponList.vue
+++ b/src/views/Marketing/CouponList.vue
@@ -92,7 +92,7 @@
 
           <!-- Loading State -->
           <div v-if="appStore.isLoading || couponStore.isFetching" class="p-8 text-center">
-            <div class="inline-block animate-spin rounded-full h-8 w-8 border-b-2 border-brand-500"></div>
+            <Spinner />
             <p class="mt-2 text-gray-600 dark:text-gray-400">{{ $t('coupon.list.loading') }}</p>
           </div>
 
@@ -257,7 +257,7 @@
 import { ref, computed, onMounted, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import DictionaryLayout from '@/components/layout/DictionaryLayout.vue'
-import { PageBreadcrumb, ComponentCard, Button, Input, Tabs, useFormatDate, Badge, DropdownMenu, useConfirmModal, useAppStore, Pagination } from '@hivespace/shared'
+import { PageBreadcrumb, ComponentCard, Button, Input, Tabs, useFormatDate, Badge, DropdownMenu, useConfirmModal, useAppStore, Pagination, Spinner } from '@hivespace/shared'
 import { GridIcon, BoxIcon, LockIcon, PercentageIcon, FixedAmountIcon, HorizontalDots, EyeIcon, EditIcon, CopyIcon, TrashRedIcon, CloseIcon } from '@/icons'
 import { CouponType, CouponStatus, DiscountType } from '@/types'
 import type { CouponSummaryDto } from '@/types'

--- a/src/views/Orders/OrderManagementView.vue
+++ b/src/views/Orders/OrderManagementView.vue
@@ -86,9 +86,7 @@
 
         <!-- Loading -->
         <div v-if="orderStore.isFetching" class="p-12 text-center">
-          <div
-            class="inline-block animate-spin rounded-full h-8 w-8 border-b-2 border-brand-500"
-          ></div>
+          <Spinner />
         </div>
 
         <template v-else>
@@ -311,6 +309,7 @@ import {
   Pagination,
   Avatar,
   FilterChips,
+  Spinner,
 } from '@hivespace/shared'
 import { MailIcon, ArrowDownRedIcon, ListIcon } from '@/icons'
 import { OrderTabStatus, OrderType, OrderProcessStatus } from '@/types'

--- a/src/views/Products/ProductList.vue
+++ b/src/views/Products/ProductList.vue
@@ -37,7 +37,7 @@
 
           <!-- Loading State -->
           <div v-if="loading" class="p-8 text-center">
-            <div class="inline-block animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600"></div>
+            <Spinner />
             <p class="mt-2 text-gray-600 dark:text-gray-400">{{ $t('table.loading') }}</p>
           </div>
 
@@ -124,7 +124,7 @@
 <script setup lang="ts">
 import { computed, ref, onMounted } from 'vue'
 import { useI18n } from 'vue-i18n'
-import { Button, Select, Input, PageBreadcrumb, ComponentCard } from '@hivespace/shared'
+import { Button, Select, Input, PageBreadcrumb, ComponentCard, Spinner } from '@hivespace/shared'
 import DictionaryLayout from '@/components/layout/DictionaryLayout.vue'
 import { useConfirmModal } from '@hivespace/shared'
 import { productService } from '@/services'


### PR DESCRIPTION
## Summary
- Replace all inline `animate-spin` divs in `CouponList`, `OrderManagementView`, and `ProductList` with `<Spinner />` from `@hivespace/shared`
- Bump `@hivespace/shared` from `^1.1.14` to `^1.1.16`
- Add **Loading States** section to `CLAUDE.md` and `AGENTS.md` requiring use of `Spinner` and `FullscreenLoader` for all loading UI

## Test plan
- [ ] Visit Coupon List page — spinner renders correctly while data loads
- [ ] Visit Order Management page — spinner renders correctly while data loads
- [ ] Visit Product List page — spinner renders correctly while data loads
- [ ] Verify no raw `animate-spin` divs remain in modified files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added loading state specifications to development guidelines, documenting required shared components for inline and full-screen loading scenarios.

* **Refactor**
  * Standardized loading indicators across product, order, and coupon list views using shared UI components.

* **Chores**
  * Updated shared component library dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->